### PR TITLE
Fix/name data

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - uses: pre-commit/action@v3.0.1
 
   Tests:
@@ -29,9 +29,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         os: [ubuntu-latest]
-        env: [ci/envs/311-tests.yaml]
+        env: [ci/envs/312-tests.yaml]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ MIT license. Data licenses can be found in the respective STAC collection.
 
 ## Credits
 
-Initial template of `coastpy` was created with [`cookiecutter`](https://cookiecutter.readthedocs.io/en/latest/) and the `py-pkgs-cookiecutter` [template](https://github.com/py-pkgs/py-pkgs-cookiecutter). 
+Initial template of `coastpy` was created with [`cookiecutter`](https://cookiecutter.readthedocs.io/en/latest/) and the `py-pkgs-cookiecutter` [template](https://github.com/py-pkgs/py-pkgs-cookiecutter).

--- a/ci/envs/312-tests.yaml
+++ b/ci/envs/312-tests.yaml
@@ -1,0 +1,58 @@
+name: 312-release
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.12
+  - pip
+  - affine
+  - dask
+  - dask-geopandas
+  - duckdb
+  - fsspec
+  - geopandas
+  - geopy
+  - matplotlib
+  - mercantile
+  - numpy
+  - pandas
+  - poetry
+  - pyarrow
+  - pyproj
+  - pystac
+  - python-dotenv
+  - rasterio
+  - rioxarray
+  - shapely
+  - stac-geoparquet
+  - xarray
+
+  # Dev dependencies
+  - bandit
+  - black
+  - cattrs
+  - click
+  - codespell
+  - flake8
+  - isort
+  - mypy
+  - nbsphinx
+  - poetry
+  - pre-commit
+  - pydantic
+  - pytest
+  - pytest-cov
+  - recommonmark
+  - ruff
+  - setuptools
+  - sphinx
+  - sphinx-autodoc-typehints
+  - sphinx-rtd-theme
+  - sphinx_rtd_theme
+
+
+  - pip:
+      - antimeridian
+      - duckdb
+      - more-itertools

--- a/scripts/python/make_gcts.py
+++ b/scripts/python/make_gcts.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
     with fsspec.open(utm_grid_url, **storage_options) as f:
         utm_grid = gpd.read_parquet(f)
 
-    withr fsspec.open(countries_url, **storage_options) as f:
+    with fsspec.open(countries_url, **storage_options) as f:
         countries = gpd.read_parquet(f)
 
     utm_grid = utm_grid.dissolve("epsg").to_crs(prc_epsg).reset_index()
@@ -539,8 +539,8 @@ if __name__ == "__main__":
     # )
     # partitioner.process()
 
-    # logging.info("Done!")
-    # elapsed_time = time.time() - start_time
-    # logging.info(
-    #     f"Time (H:M:S): {time.strftime('%H:%M:%S', time.gmtime(elapsed_time))}"
-    # )
+    logging.info("Done!")
+    elapsed_time = time.time() - start_time
+    logging.info(
+        f"Time (H:M:S): {time.strftime('%H:%M:%S', time.gmtime(elapsed_time))}"
+    )

--- a/src/coastpy/geo/ops.py
+++ b/src/coastpy/geo/ops.py
@@ -130,7 +130,7 @@ def extract_coordinates(pt: Point | tuple[float, float]) -> tuple[float, float]:
     elif (
         isinstance(pt, tuple)
         and len(pt) == 2
-        and all(isinstance(coord, (float, int)) for coord in pt)
+        and all(isinstance(coord, (float | int)) for coord in pt)
     ):
         return float(pt[0]), float(pt[1])
     else:

--- a/src/coastpy/geo/quadtiles_utils.py
+++ b/src/coastpy/geo/quadtiles_utils.py
@@ -138,9 +138,11 @@ def add_geo_columns(
     # Add quadkey column
     if "quadkey" in geo_columns:
         if quadkey_zoom_level is None:
-            raise ValueError(
+            message = (
                 "quadkey_zoom_level must be provided when 'quadkey' is in geo_columns."
             )
+            raise ValueError(message)
+
         if "lon" in df.columns and "lat" in df.columns:
             points = gpd.GeoSeries(
                 [Point(xy) for xy in zip(df.lon, df.lat, strict=False)], crs="EPSG:4326"

--- a/src/coastpy/io/utils.py
+++ b/src/coastpy/io/utils.py
@@ -201,24 +201,20 @@ def name_data(
 
     # Generate bounds part
     bounds_part = ""
+    if isinstance(data, pd.DataFrame | gpd.GeoDataFrame):
+        suffix = ".parquet"
+
     if include_bounds and isinstance(
         data, gpd.GeoDataFrame | xarray.Dataset | xarray.DataArray
     ):
-        if isinstance(data, pd.DataFrame):
-            suffix = ".parquet"
-
-        elif isinstance(data, gpd.GeoDataFrame):
-            suffix = ".parquet"
+        if isinstance(data, gpd.GeoDataFrame):
             bounds = data.total_bounds
             crs = data.crs.to_string()
 
-        elif isinstance(data, xr.DataArray | xr.Dataset):  # xarray
+        else:
             suffix = ".tif"
             bounds = data.rio.bounds()
             crs = data.rio.crs.to_string()
-        else:
-            message = f"Unsupported data type: {type(data)}"
-            raise ValueError(message)
 
         def name_bounds(bounds, crs):
             bounds_geometry = box(*bounds)

--- a/src/coastpy/io/utils.py
+++ b/src/coastpy/io/utils.py
@@ -197,7 +197,6 @@ def name_data(
         msg = "At least one of include_bounds, include_random_hex or quadkey_prefix must be set."
         raise ValueError(msg)
 
-    suffix = ".parquet"  # Default suffix for non-spatial data
     parts = []
 
     # Generate bounds part
@@ -205,12 +204,21 @@ def name_data(
     if include_bounds and isinstance(
         data, gpd.GeoDataFrame | xarray.Dataset | xarray.DataArray
     ):
-        if isinstance(data, gpd.GeoDataFrame):
+        if isinstance(data, pd.DataFrame):
+            suffix = ".parquet"
+
+        elif isinstance(data, gpd.GeoDataFrame):
+            suffix = ".parquet"
             bounds = data.total_bounds
             crs = data.crs.to_string()
-        else:  # xarray
+
+        elif isinstance(data, xr.DataArray | xr.Dataset):  # xarray
+            suffix = ".tif"
             bounds = data.rio.bounds()
             crs = data.rio.crs.to_string()
+        else:
+            message = f"Unsupported data type: {type(data)}"
+            raise ValueError(message)
 
         def name_bounds(bounds, crs):
             bounds_geometry = box(*bounds)


### PR DESCRIPTION
This fixes `coastpy.io.utils.name_data` so that it no longer assumes a ".parquet" suffix. It will determine the suffix based on the instance type: a) `pd.DataFrame | gpd.GeoDataFrame` will be ".parquet" and `xr.DataArray | xr.Dataset` will be ".tif". 