### PR TITLE
Fix/stac pyproj

### DIFF
--- a/src/coastpy/io/engine.py
+++ b/src/coastpy/io/engine.py
@@ -107,9 +107,12 @@ class STACQueryEngine(BaseQueryEngine):
     ) -> None:
         super().__init__(storage_backend=storage_backend)
         self.extents = read_snapshot(
-            stac_collection, columns=["geometry", "assets", "proj:code"], add_href=True
+            stac_collection,
         )
-        self.proj_epsg = self.extents["proj:code"].unique().item()
+        try:
+            self.proj_epsg = self.extents["proj:code"].unique().item()
+        except KeyError:
+            self.proj_epsg = self.extents["proj:epsg"].unique().item()
 
         if columns is None or not columns:
             # NOTE: before we used a wildcard, but that was tricky.. now we will rely on STAC? Also a bit

--- a/tutorials/shorelinemonitor_shorelines.ipynb
+++ b/tutorials/shorelinemonitor_shorelines.ipynb
@@ -265,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/tutorials/shorelinemonitor_shorelines.ipynb
+++ b/tutorials/shorelinemonitor_shorelines.ipynb
@@ -247,6 +247,14 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- backwards compatible reading of STAC metadata from the projection extension (i.e., both proj:code and proj:epsg). 